### PR TITLE
Improve the extensibility of the library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ All changes are expected to be tested thoroughly prior to submission. Any untest
 History
 -------
 
-* **1.2.2**: Improve the extensibility of the library by allowing DAO creation from an `EntityConfiguration` to support dynamically generated entities.
+* **1.3.0**: Improve the extensibility of the library by allowing DAO creation from an `EntityConfiguration` to support dynamically generated entities.
 
 * **1.2.1**: Implement `equals` and `hashCode` methods on `StringKey`.
 

--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ All changes are expected to be tested thoroughly prior to submission. Any untest
 History
 -------
 
+* **1.2.2**: Improve the extensibility of the library by allowing DAO creation from an `EntityConfiguration` to support dynamically generated entities.
+
 * **1.2.1**: Implement `equals` and `hashCode` methods on `StringKey`.
 
 * **1.2.0**: Add batch read/write/delete functionality. Deprecate single-row operations to encourage use of batch operations.

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.bettercloud'
-version = '1.2.2'
+version = '1.3.0'
 
 ext.isReleaseVersion = !version.endsWith('SNAPSHOT')
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.bettercloud'
-version = '1.2.1'
+version = '1.2.2'
 
 ext.isReleaseVersion = !version.endsWith('SNAPSHOT')
 

--- a/compiler/src/test/java/com/bettercloud/bigtable/orm/GeneratedColumnTest.java
+++ b/compiler/src/test/java/com/bettercloud/bigtable/orm/GeneratedColumnTest.java
@@ -21,7 +21,7 @@ public class GeneratedColumnTest {
 
         assertNotNull(entityConfiguration);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> result = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> result = entityConfiguration.getColumns();
 
         assertNotNull(result);
         assertEquals(1, StreamSupport.stream(result.spliterator(), false).count());
@@ -33,7 +33,7 @@ public class GeneratedColumnTest {
 
         assertNotNull(entityConfiguration);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final List<com.bettercloud.bigtable.orm.Column> results = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityConfigurationTableConfiguration.SingleColumnEntity.COLUMN_FAMILY.equals(column.getFamily()))
@@ -52,7 +52,7 @@ public class GeneratedColumnTest {
 
         assertNotNull(entityConfiguration);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final List<com.bettercloud.bigtable.orm.Column> results = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityConfigurationTableConfiguration.InferredColumnQualifierEntity.COLUMN_FAMILY.equals(column.getFamily()))
@@ -71,7 +71,7 @@ public class GeneratedColumnTest {
 
         assertNotNull(entityConfiguration);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final List<com.bettercloud.bigtable.orm.Column> results1 = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityConfigurationTableConfiguration.MultiColumnEntity.COLUMN_FAMILY_1.equals(column.getFamily()))
@@ -100,7 +100,7 @@ public class GeneratedColumnTest {
 
         assertNotNull(entityConfiguration);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final List<com.bettercloud.bigtable.orm.Column> results = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityConfigurationTableConfiguration.PrimitiveColumnEntity.COLUMN_FAMILY.equals(column.getFamily()))
@@ -119,7 +119,7 @@ public class GeneratedColumnTest {
 
         assertNotNull(entityConfiguration);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final List<com.bettercloud.bigtable.orm.Column> results = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityConfigurationTableConfiguration.VersionedColumnEntity.COLUMN_FAMILY.equals(column.getFamily()))
@@ -138,7 +138,7 @@ public class GeneratedColumnTest {
 
         assertNotNull(entityConfiguration);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final List<com.bettercloud.bigtable.orm.Column> results1 = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityConfigurationTableConfiguration.MultiVersionedColumnEntity.COLUMN_FAMILY_1.equals(column.getFamily()))

--- a/compiler/src/test/java/com/bettercloud/bigtable/orm/GeneratedEntityDelegateTest.java
+++ b/compiler/src/test/java/com/bettercloud/bigtable/orm/GeneratedEntityDelegateTest.java
@@ -24,7 +24,7 @@ public class GeneratedEntityDelegateTest {
 
         final EntityConfiguration.EntityDelegate<EntityDelegateEntity> delegate = entityConfiguration.getDelegateForEntity(entity);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final com.bettercloud.bigtable.orm.Column stringValueColumn = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityDelegateTableConfiguration.EntityDelegateEntity.COLUMN_FAMILY_1.equals(column.getFamily()))
@@ -71,7 +71,7 @@ public class GeneratedEntityDelegateTest {
 
         final EntityConfiguration.EntityDelegate<EntityDelegateEntity> delegate = entityConfiguration.getDelegateForEntity(entity);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final com.bettercloud.bigtable.orm.Column stringValueColumn = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityDelegateTableConfiguration.EntityDelegateEntity.COLUMN_FAMILY_1.equals(column.getFamily()))
@@ -98,7 +98,7 @@ public class GeneratedEntityDelegateTest {
 
         final EntityConfiguration.EntityDelegate<EntityDelegateEntity> delegate = entityConfiguration.getDelegateForEntity(entity);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final com.bettercloud.bigtable.orm.Column stringValueColumn = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityDelegateTableConfiguration.EntityDelegateEntity.COLUMN_FAMILY_1.equals(column.getFamily()))
@@ -121,7 +121,7 @@ public class GeneratedEntityDelegateTest {
 
         final EntityConfiguration.EntityDelegate<EntityDelegateEntity> delegate = entityConfiguration.getDelegateForEntity(entity);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final com.bettercloud.bigtable.orm.Column stringValueColumn = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityDelegateTableConfiguration.EntityDelegateEntity.COLUMN_FAMILY_1.equals(column.getFamily()))
@@ -144,7 +144,7 @@ public class GeneratedEntityDelegateTest {
 
         final EntityConfiguration.EntityDelegate<EntityDelegateEntity> delegate = entityConfiguration.getDelegateForEntity(entity);
 
-        final Iterable<com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
+        final Iterable<? extends com.bettercloud.bigtable.orm.Column> columns = entityConfiguration.getColumns();
 
         final com.bettercloud.bigtable.orm.Column intValueColumn = StreamSupport.stream(columns.spliterator(), false)
                 .filter(column -> EntityDelegateTableConfiguration.EntityDelegateEntity.COLUMN_FAMILY_3.equals(column.getFamily()))

--- a/core/src/main/java/com/bettercloud/bigtable/orm/BigTableEntityDao.java
+++ b/core/src/main/java/com/bettercloud/bigtable/orm/BigTableEntityDao.java
@@ -27,13 +27,13 @@ import java.util.stream.IntStream;
 class BigTableEntityDao<T extends Entity> implements Dao<T> {
 
     private final Table table;
-    private final Iterable<Column> columns;
+    private final Iterable<? extends Column> columns;
     private final Supplier<T> entityFactory;
     private final Function<T, EntityConfiguration.EntityDelegate<T>> delegateFactory;
     private final ObjectMapper objectMapper;
 
     BigTableEntityDao(final Table table,
-                      final Iterable<Column> columns,
+                      final Iterable<? extends Column> columns,
                       final Supplier<T> entityFactory,
                       final Function<T, EntityConfiguration.EntityDelegate<T>> delegateFactory,
                       final ObjectMapper objectMapper) {
@@ -45,7 +45,7 @@ class BigTableEntityDao<T extends Entity> implements Dao<T> {
     }
 
     BigTableEntityDao(final Table table,
-                      final Iterable<Column> columns,
+                      final Iterable<? extends Column> columns,
                       final Supplier<T> entityFactory,
                       final Function<T, EntityConfiguration.EntityDelegate<T>> delegateFunction) {
         this(table, columns, entityFactory, delegateFunction, new ObjectMapper());

--- a/core/src/main/java/com/bettercloud/bigtable/orm/EntityConfiguration.java
+++ b/core/src/main/java/com/bettercloud/bigtable/orm/EntityConfiguration.java
@@ -6,7 +6,7 @@ public interface EntityConfiguration<T extends Entity> {
 
     String getDefaultTableName();
 
-    Iterable<Column> getColumns();
+    Iterable<? extends Column> getColumns();
 
     Supplier<T> getEntityFactory();
 

--- a/core/src/test/java/com/bettercloud/bigtable/orm/DaoFactoryTest.java
+++ b/core/src/test/java/com/bettercloud/bigtable/orm/DaoFactoryTest.java
@@ -105,8 +105,44 @@ public class DaoFactoryTest {
         verify(connection).getTable(eq(TableName.valueOf(tableName)));
     }
 
+    @Test
+    public void testDaoForUnRegisteredEntityTypeReturnsDaoForEntityConfiguration() throws IOException {
+        final Table table = mock(Table.class);
+        when(connection.getTable(TableName.valueOf(TABLE_NAME))).thenReturn(table);
+
+        final Dao<UnregisteredEntity> unregisteredEntityDao = daoFactory.daoFor(UnregisteredEntity.TestConfiguration.INSTANCE, null);
+
+        assertNotNull(unregisteredEntityDao);
+
+        verify(connection).getTable(eq(TableName.valueOf(TABLE_NAME)));
+    }
+
     private static class UnregisteredEntity implements Entity {
-        // Nothing to see here
+
+        private static class TestConfiguration implements EntityConfiguration<UnregisteredEntity> {
+
+            private static final EntityConfiguration<UnregisteredEntity> INSTANCE = new UnregisteredEntity.TestConfiguration();
+
+            @Override
+            public String getDefaultTableName() {
+                return TABLE_NAME;
+            }
+
+            @Override
+            public Iterable<Column> getColumns() {
+                return null;
+            }
+
+            @Override
+            public Supplier<UnregisteredEntity> getEntityFactory() {
+                return null;
+            }
+
+            @Override
+            public EntityDelegate<UnregisteredEntity> getDelegateForEntity(final UnregisteredEntity entity) {
+                return null;
+            }
+        }
     }
 
     private static class RegisteredEntity extends RegisterableEntity {


### PR DESCRIPTION
Made changes to allow the generation of DAO using an EntityConfiguration.  This is to support entities that have been dynamically configured at runtime as opposed to entities generated via annotation/compilation.